### PR TITLE
Configure System properties role

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ the function in an Ansible playbook.
 * edit [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/config_manager/edit.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/config_manager/edit.md)
 * get_facts [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/get_facts.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/get_facts.md)
 * configure_netconf [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/configure_netconf.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/configure_netconf.md)
+* configure_system_properties [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/configure_system_properties.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/configure_system_properties.md)
 
 ## License
 

--- a/docs/configure_system_properties.md
+++ b/docs/configure_system_properties.md
@@ -1,0 +1,171 @@
+# Configure System properties on the device
+
+The `configure_system_properties` function can be used to set system properties on 
+Juniper Junos devices.  This function is only supported over `network_cli` connection
+type and requires the `ansible_network_os` value set to `junos`.
+
+## How to set System properties on the device
+
+To set System properties on the device, simply include this function in the playbook
+using either the `roles` directive or the `tasks` directive.  If no other
+options are provided, then all of the available facts will be collected for the
+device.
+
+Below is an example of how to use the `roles` directive to set system properties
+on the Juniper Junos device.
+
+```
+- hosts: junos
+
+  roles:
+  - name ansible-network.juniper_junos
+    function: configure_system_properties
+  vars:
+    system_properties:
+      - hostname: test-
+        domain_name: hostname.com
+        name_server: 192.168.1.1
+        vrf_routing_instance: test
+        vrf_interface: ge-0/0/2
+        vrf_route_distinguisher: 10.58.255.1:37
+        vrf_target: target:10.58.255.1:37
+        vrf_import_policy:
+        vrf_export_policy:
+        vrf_table_label: static
+        vrf_table_static_value: 24
+```
+
+The above playbook will set the hostname, domain-name and the name-server values to
+the host under the `junos` top level key.  
+
+### Implement using tasks
+
+The `configure_system_properties` function can also be implemented using the `tasks` 
+directive instead of the `roles` directive.  By using the `tasks` directive, you can
+control when the fact collection is run. 
+
+Below is an example of how to use the `configure_system_properties` function with `tasks`.
+
+```
+- hosts: junos
+
+  tasks:
+    - name: set system properties to junos devices
+      import_role:
+        name: ansible-network.juniper_junos
+        tasks_from: configure_system_properties
+      vars:
+        system_properties:
+          - hostname: test-vyos
+            domain_name: hostname.com
+            name_server: 192.168.1.1
+            vrf_routing_instance: test
+            vrf_interface: ge-0/0/2
+            vrf_route_distinguisher: 10.58.255.1:37
+            vrf_target: target:10.58.255.1:37
+            vrf_import_policy:
+            vrf_export_policy:
+            vrf_table_label: static
+            vrf_table_static_value: 24
+```
+
+## Adding new parsers
+
+Over time new parsers can be added (or updated) to the role to add additional
+or enhanced functionality.  To add or update parsers perform the following
+steps:
+
+* Add (or update) command parser located in `parse_templates/cli`
+
+## Arguments
+
+### hostname
+
+This will set the System host name for the VyOS device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### domain_name
+
+This will set the System domain name for the Juniper Junos device.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### name_server
+
+This will set the Domain Name Server (DNS) for the Juniper Junos device.
+
+The default value is `omit` which means even if the user doesn't pass the respective 
+value the role will continue to run without any failure.
+
+### vrf_routing_instance
+
+This will set the Routing instance name for the Juniper Junos device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_interface
+
+This will set the Interface name for routing instance for the Juniper Junos device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_route_distinguisher
+
+This will set the Route distinguisher for instance for the Juniper Junos device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_target
+
+This will set the VRF target community configuration for the Juniper Junos device.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_import_policy
+
+This will set the Import policy for VRF instance RIBs.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_export_policy
+
+This will set the Export policy for VRF instance RIBs
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_table_label
+
+This will set and advertise a single VPN label for all routes in the VRF
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### vrf_table_static_value
+
+This will set VRF static label value that will be used. Range(16..1048575).
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### state
+
+This will set the hostname, domain-name and name-server value to the VyOS device and if
+the value of the state is changed to `absent`, role will go ahead and try to delete the
+hostname, domain-name and name-server passed via the arguments.
+
+The default value is `present` which means even if the user doesn't pass the respective
+argument, the role will go ahead and try to set the hostname, domain-name and name-server 
+via the arguments passed to the Juniper Junos device.
+
+## Notes
+
+None

--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -24,3 +24,4 @@
       - get_facts
       - configure_netconf
       - configure_user
+      - configure_system_properties

--- a/meta/configure_system_properties_spec.yaml
+++ b/meta/configure_system_properties_spec.yaml
@@ -1,0 +1,7 @@
+---
+argument_spec:
+  ansible_network_os:
+    description:
+    - Set the name of the Ansible network OS platform.  This value should be
+      set to `junos` for this provider.
+    required: yes

--- a/tasks/configure_system_properties.yaml
+++ b/tasks/configure_system_properties.yaml
@@ -1,0 +1,36 @@
+---
+#- name: validate role spec
+#  validate_role_spec:
+#    spec: configure_system_property_spec.yaml
+#  delegate_to: localhost
+
+- name: "check if vrf-table-label static value is greater than 16"
+  fail:
+    msg: "vrf table static value should be greater than 16 (valid-range: 16-1048575)"
+  loop: "{{ system_properties }}"
+  loop_control:
+    loop_var: sys_prop
+  when:
+    - sys_prop.vrf_table_static_value is defined
+    - sys_prop.vrf_table_static_value < 16
+  delegate_to: localhost
+
+- name: "check if vrf-table-label static value is less than 1048575"
+  fail:
+    msg: "vrf table static value should be less than 1048575 (valid-range: 16-1048575)"
+  loop: "{{ system_properties }}"
+  loop_control:
+    loop_var: sys_prop
+  when:
+    - sys_prop.vrf_table_static_value is defined
+    - sys_prop.vrf_table_static_value > 1048575
+  delegate_to: localhost
+
+- name: "fetch template for configuring system properties"
+  set_fact:
+    junos_config_text: "{{ lookup('config_template', 'configure_system_properties.j2') }}"
+  when: system_properties
+  delegate_to: localhost
+
+- include_tasks: config_manager/load.yaml
+  when: system_properties

--- a/tasks/configure_system_properties.yaml
+++ b/tasks/configure_system_properties.yaml
@@ -1,8 +1,8 @@
 ---
-#- name: validate role spec
-#  validate_role_spec:
-#    spec: configure_system_property_spec.yaml
-#  delegate_to: localhost
+- name: validate role spec
+  validate_role_spec:
+    spec: configure_system_property_spec.yaml
+  delegate_to: localhost
 
 - name: "check if vrf-table-label static value is greater than 16"
   fail:

--- a/templates/configure_system_properties.j2
+++ b/templates/configure_system_properties.j2
@@ -1,0 +1,44 @@
+{% for sys_prop in system_properties %}
+
+{% if sys_prop.state is defined and sys_prop.state == 'absent' %}
+delete system host-name {{ sys_prop.host_name }}
+delete system domain-name {{ sys_prop.domain_name }}
+delete system name-server {{ sys_prop.name_server }}
+delete routing-instances {{ sys_prop.vrf_routing_instance }}
+
+{% else %}
+
+set system host-name {{ sys_prop.host_name | default(omit) }}
+set system domain-name {{ sys_prop.domain_name | default(omit) }}
+set system name-server {{ sys_prop.name_server | default(omit) }}
+
+{% if sys_prop.vrf_routing_instance is defined %}
+
+set routing-instances {{ sys_prop.vrf_routing_instance }} instance-type vrf
+set routing-instances {{ sys_prop.vrf_routing_instance }} interface {{ sys_prop.vrf_interface }}
+set routing-instances {{ sys_prop.vrf_routing_instance }} route-distinguisher {{ sys_prop.vrf_route_distinguisher }}
+
+{% if sys_prop.vrf_target is defined %}
+set routing-instances {{ sys_prop.vrf_routing_instance }} vrf-target {{ sys_prop.vrf_target }}
+{% endif %}
+
+{% if sys_prop.vrf_import is defined %}
+set routing-instances {{ sys_prop.vrf_routing_instance }} vrf-import {{ sys_prop.vrf_import }}
+{% endif %}
+
+{% if sys_prop.vrf_export is defined %}
+set routing-instances {{ sys_prop.vrf_routing_instance }} vrf-export {{ sys_prop.vrf_export }}
+{% endif %}
+
+{% if sys_prop.vrf_table_label is defined and sys_prop.vrf_table_label == 'source-class-usage' %}
+set routing-instances {{ sys_prop.vrf_routing_instance }} vrf-table-label {{ sys_prop.vrf_table_label }}
+{% elif sys_prop.vrf_table_label is defined and sys_prop.vrf_table_label == 'static' and sys_prop.vrf_table_static_value is defined %}
+set routing-instances {{ sys_prop.vrf_routing_instance }} vrf-table-label static {{ sys_prop.vrf_table_static_value }}
+{% else %}
+set routing-instances {{ sys_prop.vrf_routing_instance }} vrf-table-label
+{% endif %}
+
+{% endif %}
+
+{% endif %}
+{% endfor %}

--- a/tests/configure_system_properties/tasks/configure_system_properties.yaml
+++ b/tests/configure_system_properties/tasks/configure_system_properties.yaml
@@ -1,0 +1,64 @@
+---
+- debug: 
+    msg: "START configure_vlans function on connection={{ ansible_connection }}"
+
+- name: ensure netconf is enabled
+  junos_netconf:
+    netconf_port: "{{ netconf_port }}"
+
+- name: setup - remove user config
+  junos_config: &rm
+    lines:
+      - delete vlan_10
+      - delete vlan_20
+      - delete vlan_30
+  connection: netconf
+
+- name: include juniper_junos load function
+  include_role:
+    name: "{{ juniper_junos_role_path }}"
+    tasks_from: configure_vlans
+  vars:
+    system_properties:
+      - host_name: test-sys-prop
+        domain_name: hostname.com
+        name_server: 192.168.1.1
+        vrf_routing_instance: test
+        vrf_interface: ge-0/0/2
+        vrf_route_distinguisher: 10.58.255.1:37
+        vrf_target: target:10.58.255.1:37
+      - host_name: test_sys_prop
+        domain_name: hostname.com
+        name_server: 192.168.1.1
+        vrf_routing_instance: test
+        vrf_interface: ge-0/0/2
+        vrf_route_distinguisher: 10.58.255.1:37
+        vrf_target: target:10.58.255.1:37
+
+- name: fetch system properties config
+  junos_command:
+    commands: show configuration system | display set
+  register: show_system_result
+
+- assert:
+    that:
+      - "'set system host-name test-sys-prop' in show_system_result.stdout_lines[0]"
+      - "'set system domain-name hostname.com' in show_system_result.stdout_lines[0]"
+      - "'set system name-server 192.168.1.1' in show_system_result.stdout_lines[0]"
+
+- name: fetch system properties vrf config
+  junos_command:
+    commands: show configuration routing-instances | display set
+  register: show_system_vrf_result
+
+- assert:
+    that:
+      - "'set vlans vlan_10 vlan-id 10' in show_system_vrf_result.stdout_lines[0]"
+      - "'set vlans vlan_20 vlan-id 20' in show_system_vrf_result.stdout_lines[0]"
+      - "'set vlans vlan_30 vlan-id 30' in show_system_vrf_result.stdout_lines[0]"
+
+ - name: teardown - remove vlan config
+  junos_config: *rm
+  connection: netconf
+ - debug: 
+    msg: "END configure_vlans function on connection={{ ansible_connection }}"

--- a/tests/configure_system_properties/tasks/configure_system_properties.yaml
+++ b/tests/configure_system_properties/tasks/configure_system_properties.yaml
@@ -1,6 +1,6 @@
 ---
 - debug: 
-    msg: "START configure_vlans function on connection={{ ansible_connection }}"
+    msg: "START configure_system_properties function on connection={{ ansible_connection }}"
 
 - name: ensure netconf is enabled
   junos_netconf:
@@ -9,9 +9,10 @@
 - name: setup - remove user config
   junos_config: &rm
     lines:
-      - delete vlan_10
-      - delete vlan_20
-      - delete vlan_30
+      - delete system host-name test-sys-prop
+      - delete system domain-name hostname.com
+      - delete system name-server 192.168.1.1
+      - delete routing-instances test
   connection: netconf
 
 - name: include juniper_junos load function
@@ -53,11 +54,12 @@
 
 - assert:
     that:
-      - "'set vlans vlan_10 vlan-id 10' in show_system_vrf_result.stdout_lines[0]"
-      - "'set vlans vlan_20 vlan-id 20' in show_system_vrf_result.stdout_lines[0]"
-      - "'set vlans vlan_30 vlan-id 30' in show_system_vrf_result.stdout_lines[0]"
+      - "'set routing-instances test instance-type vrf' in show_system_vrf_result.stdout_lines[0]"
+      - "'set routing-instances test interface ge-0/0/2.0' in show_system_vrf_result.stdout_lines[0]"
+      - "'set routing-instances test route-distinguisher 10.58.255.1:37' in show_system_vrf_result.stdout_lines[0]"
+      - "'set routing-instances test vrf-target target:10.58.255.1:37' in show_system_vrf_result.stdout_lines[0]"
 
- - name: teardown - remove vlan config
+ - name: teardown - remove system properties config
   junos_config: *rm
   connection: netconf
  - debug: 

--- a/tests/configure_system_properties/tasks/main.yaml
+++ b/tests/configure_system_properties/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: set role path
+  set_fact:
+    juniper_junos_role_path: "{{ role_path.split('/tests/configure_system_properties/configure_system_properties')[0] }}"
+ - name: test configure_system_properties function
+  import_tasks: configure_system_properties.yaml

--- a/tests/configure_system_properties/test.yaml
+++ b/tests/configure_system_properties/test.yaml
@@ -1,0 +1,6 @@
+- hosts: appliance
+  connection: network_cli
+  roles:
+    - configure_system_properties
+  vars:
+    netconf_port: 830


### PR DESCRIPTION
Added `configure_system_properties` and `configure_system_properties` jinja template for junos provider to configure System properties using junos provider role.

To configure System properties via this role user needs to build their playbook as:
```
---
- hosts: junos
  gather_facts: no
  tasks:
    - import_role:
        name: juniper_junos
        tasks_from: configure_system_properties
      vars:
        system_properties:
          - host_name: test-host
            domain_name: hostname.com
            name_server: 192.168.1.1
            vrf_routing_instance: test
            vrf_interface: ge-0/0/2
            vrf_route_distinguisher: 10.58.255.1:37
            vrf_target: target:10.58.255.1:37
            #vrf_import_policy:
            #vrf_export_policy:
            vrf_table_label: static
            vrf_table_static_value: 24
            #state: absent
```

