### PR TITLE
Added Configure Vlans for junos provider

### DIFF
--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -24,3 +24,4 @@
       - get_facts
       - configure_netconf
       - configure_user
+      - configure_vlan

--- a/meta/configure_vlan_spec.yaml
+++ b/meta/configure_vlan_spec.yaml
@@ -1,0 +1,18 @@
+---
+argument_spec:
+  ansible_network_os:
+    description:
+    - Set the name of the Ansible network OS platform.  This value should be
+      set to `junos` for this provider.
+    required: yes
+
+  id:
+    description:
+    - Provide the vlan name that need to be configured to the device
+    required: yes
+
+  name:
+    description:
+    - Provide the vlan name that need to be configured to the device on the 
+      particular vlan id
+    required: yes

--- a/tasks/configure_vlans.yaml
+++ b/tasks/configure_vlans.yaml
@@ -1,0 +1,38 @@
+---
+- name: validate role spec
+  validate_role_spec:
+    spec: configure_vlan_spec.yaml
+  delegate_to: localhost
+
+- name: "check if vlan ID is greater than 1"
+  fail:
+    msg: "vlan_id is less than 1 (valid-range: 1-4094)"
+  loop: "{{ vlans }}"
+  loop_control:
+    loop_var: vlan
+  when:
+    - vlan.id < 1
+  delegate_to: localhost
+
+- name: "check if vlan ID is less than 4094"
+  fail:
+    msg: "vlan_id is greater than 4094 (valid-range: 1-4094)"
+  loop: "{{ vlans }}"
+  loop_control:
+    loop_var: vlan
+  when:
+    - vlan.id > 4094
+  delegate_to: localhost
+
+- name: "fetch existing vlan(s)"
+  cli:
+    command: show vlans
+  register: vlan_output
+
+- name: "fetch template for configuring vlan(s)"
+  set_fact:
+    junos_config_text: "{{ lookup('config_template', 'configure_vlans.j2') }}"
+  delegate_to: localhost
+
+- include_tasks: config_manager/load.yaml
+  delegate_to: localhost

--- a/templates/configure_vlans.j2
+++ b/templates/configure_vlans.j2
@@ -1,0 +1,19 @@
+{% for vlan in vlans %}
+
+{% if vlan.state is defined and vlan.state == 'absent' %}
+delete vlans {{ vlan.name }}
+
+{% else %}
+
+set vlans {{ vlan.name }} vlan-id {{ vlan.id }}
+
+{% if vlan.description is defined %}
+set vlans {{ vlan.name }} description "{{ vlan.description }}"
+{% endif %}
+
+{% if vlan.interface is defined %}
+set interfaces {{ vlan.interface }} unit 0 family ethernet-switching vlan members {{ vlan.name }}
+{% endif %}
+
+{% endif %}
+{% endfor %}

--- a/tests/configure_vlans/tasks/configure_vlans.yaml
+++ b/tests/configure_vlans/tasks/configure_vlans.yaml
@@ -1,0 +1,48 @@
+---
+- debug: 
+    msg: "START configure_vlans function on connection={{ ansible_connection }}"
+
+- name: ensure netconf is enabled
+  junos_netconf:
+    netconf_port: "{{ netconf_port }}"
+
+- name: setup - remove vlan config
+  junos_config: &rm
+    lines:
+      - delete vlan_10
+      - delete vlan_20
+      - delete vlan_30
+  connection: netconf
+
+- name: include juniper_junos load function
+  include_role:
+    name: "{{ juniper_junos_role_path }}"
+    tasks_from: configure_vlans
+  vars:
+    vlans:
+      - name: vlan_10
+        id: 10
+
+      - name: vlan_20
+        id: 20
+
+      - name: vlan_30
+        id: 30
+
+- name: fetch vlan config
+  junos_command:
+    commands: show configuration vlans | display set
+  register: show_vlan_result
+
+- assert:
+    that:
+      - "'set vlans vlan_10 vlan-id 10' in show_vlan_result.stdout_lines[0]"
+      - "'set vlans vlan_20 vlan-id 20' in show_vlan_result.stdout_lines[0]"
+      - "'set vlans vlan_30 vlan-id 30' in show_vlan_result.stdout_lines[0]"
+
+- name: teardown - remove vlan config
+  junos_config: *rm
+  connection: netconf
+
+- debug: 
+    msg: "END configure_vlans function on connection={{ ansible_connection }}"

--- a/tests/configure_vlans/tasks/main.yaml
+++ b/tests/configure_vlans/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: set role path
+  set_fact:
+    juniper_junos_role_path: "{{ role_path.split('/tests/configure_vlans/configure_vlans')[0] }}"
+
+- name: test configure_vlans function
+  import_tasks: configure_vlans.yml

--- a/tests/configure_vlans/test.yaml
+++ b/tests/configure_vlans/test.yaml
@@ -1,0 +1,6 @@
+- hosts: appliance
+  connection: network_cli
+  roles:
+    - configure_vlans
+  vars:
+    netconf_port: 830


### PR DESCRIPTION
Added `configure_vlan` and `configure_vlan` jinja template for junos provider to configure VLANs using junos provider role.

To configure VLANs via this role user needs to build their playbook as:
```
---
- hosts: junos
  gather_facts: no
  tasks:
    - import_role:
        name: juniper_junos
        tasks_from: configure_vlans
      vars:
        vlans:
          - name: vlan30
            id: 30
            interface: ge-0/0/27
            description: this is vlan30
            #state: absent
          - name: vlan40
            id: 40
            description: this is vlan40
            #state: absent
          - name: vlan50
            id: 50
            #state: absent
```