### PR TITLE
Adding Configure lldp role support for Juniper Junos devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ the function in an Ansible playbook.
 * get_facts [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/get_facts.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/get_facts.md)
 * configure_netconf [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/configure_netconf.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/configure_netconf.md)
 * configure_system_properties [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/configure_system_properties.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/configure_system_properties.md)
+* configure_lldp [[source]](https://github.com/ansible-network/juniper_junos/blob/devel/tasks/configure_lldp.yaml) [[docs]](https://github.com/ansible-network/juniper_junos/blob/devel/docs/configure_lldp.md)
 
 ## License
 

--- a/docs/configure_lldp.md
+++ b/docs/configure_lldp.md
@@ -1,0 +1,153 @@
+# Configure LLDP on the device
+
+The `configure_lldp` function can be used to set LLDP on Juniper Junos devices.
+This function is only supported over `network_cli` connection type and 
+requires the `ansible_network_os` value set to `junos`.
+
+## How to set LLDP on the device
+
+To set LLDP on the device, simply include this function in the playbook
+using either the `roles` directive or the `tasks` directive.  If no other
+options are provided, then all of the available facts will be collected for 
+the device.
+
+Below is an example of how to use the `roles` directive to set LLDP on the
+Juniper Junos device.
+
+```
+- hosts: junos
+
+  roles:
+  - name ansible-network.juniper_junos
+    function: configure_lldp
+  vars:
+    lldp:
+      - advertisement_interval: 60 
+        hold_multiplier: 60
+        interface: all
+        lcni: 60
+        management_address: 192.168.1.1
+        pcmht: 4
+        pcti: 1
+        transmit_delay: 1
+        disble_interface: ge-0/0/2
+```
+
+The above playbook will set the LLDP with holdtime, reinit, tlv-select, receive,
+and transmit to particular interface under the `junos` top level key.  
+
+### Implement using tasks
+
+The `configure_lldp` function can also be implemented using the `tasks` directive
+instead of the `roles` directive.  By using the `tasks` directive, you can
+control when the fact collection is run. 
+
+Below is an example of how to use the `configure_lldp` function with `tasks`.
+
+```
+- hosts: junos
+
+  tasks:
+    - name: set lldp to junos devices
+      import_role:
+        name: ansible-network.juniper_junos
+        tasks_from: configure_lldp
+      vars:
+        lldp:
+          - advertisement_interval: 60
+            hold_multiplier: 60
+            interface: all
+            lcni: 60
+            management_address: 192.168.1.1
+            pcmht: 4
+            pcti: 1
+            transmit_delay: 1
+            disble_interface: ge-0/0/2
+```
+
+## Adding new parsers
+
+Over time new parsers can be added (or updated) to the role to add additional
+or enhanced functionality.  To add or update parsers perform the following
+steps:
+
+* Add (or update) command parser located in `parse_templates/cli`
+
+## Arguments
+
+### advertisement_interval
+
+LLDP advertisement_interval specifies the length of transmit interval for LLDP messages.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### hold_multiplier
+
+LLDP hold_multiplier specifies timer interval for LLDP messages.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### interface
+
+LLDP intefaces parameter sets interface configuration, valid input for the argument is
+either `all` or the `interface-name`.
+
+### lcni
+
+This is LLDP lldp-configuration-notification-interval which specifies Time interval for
+LLDP notification.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### management_address
+
+This specifies LLDP management address.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### pcti
+
+This is LLDP ptopo-configuration-trap-interval which specifies the interval for physical
+topology configuration change trap.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### pcmht
+
+This is LLDP ptopo-configuration-maximum-hold-time which specifies hold time for physical
+topology connection entries.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+
+### transmit_delay
+
+This specifies transmit delay time interval for LLDP messages.
+
+The default value is `omit` which means even if the user doesn't pass the respective
+value the role will continue to run without any failure.
+            
+### disble_interface
+
+If user needs to disable LLDP on any particular interface, then user has to specify
+respective interface name under this argument and LLDP will bbe disabled on particular
+interface.
+
+### state
+
+This sets the LLDP value to the Juniper Junos device and if the value of the state is changed
+to `absent`, the role will go ahead and try to delete the condifured LLDP via the arguments
+passed.
+
+The default value is `present` which means even if the user doesn't pass the respective
+argument, the role will go ahead and try to set the LLDP via the arguments passed to the 
+Juniper Junos device.
+
+## Notes
+
+None

--- a/includes/init.yaml
+++ b/includes/init.yaml
@@ -26,3 +26,4 @@
       - configure_user
       - configure_vlan
       - configure_system_properties
+      - configure_lldp

--- a/meta/configure_lldp_spec.yaml
+++ b/meta/configure_lldp_spec.yaml
@@ -1,0 +1,7 @@
+---
+argument_spec:
+  ansible_network_os:
+    description:
+    - Set the name of the Ansible network OS platform.  This value should be
+      set to `junos` for this provider.
+    required: yes

--- a/tasks/configure_lldp.yaml
+++ b/tasks/configure_lldp.yaml
@@ -1,0 +1,86 @@
+---
+- name: validate role spec
+  validate_role_spec:
+    spec: configure_lldp_spec.yaml
+  delegate_to: localhost
+
+- name: "check if advertisement-interval value is greater than 5 and less than 32768"
+  fail:
+    msg: "advertisement_interval (valid-range: 5-32768 seconds)"
+  loop: "{{ lldp }}"
+  loop_control:
+    loop_var: item
+  when:
+    - item.advertisement_interval is defined
+    - item.advertisement_interval > "4"
+    - item.advertisement_interval < 32768
+  delegate_to: localhost
+
+- name: "check if hold-multiplier value is greater than 2 and less than 10"
+  fail:
+    msg: "hold_multiplier (valid-range: 2-10)"
+  loop: "{{ lldp }}"
+  loop_control:
+    loop_var: item
+  when:
+    - item.hold_multiplier is defined
+    - item.hold_multiplier > 1
+    - item.hold_multiplier < 10
+  delegate_to: localhost
+
+- name: "check if lldp-configuration-notification-interval is greater than 5 and less than 3600"
+  fail:
+    msg: "lcni valid-range: 5-3600 seconds)"
+  loop: "{{ lldp }}"
+  loop_control:
+    loop_var: item
+  when:
+    - item.lcni is defined
+    - item.lcni > "4"
+    - item.lcni < 3600
+  delegate_to: localhost
+
+- name: "check if ptopo-configuration-maximum-hold-time is greater than 1 and less than 2147483647"
+  fail:
+    msg: "pcmht (valid-range: 1-2147483647 seconds)"
+  loop: "{{ lldp }}"
+  loop_control:
+    loop_var: item
+  when:
+    - item.pcmht is defined
+    - item.pcmht > "1"
+    - item.pcmht < 2147483647
+  delegate_to: localhost
+
+- name: "check if ptopo-configuration-trap-interval is greater than 0 and less than 3600"
+  fail:
+    msg: "pcti (valid-range: 0-3600)"
+  loop: "{{ lldp }}"
+  loop_control:
+    loop_var: item
+  when:
+    - item.pcti is defined
+    - item.pcti > "0"
+    - item.pcti < 3600
+  delegate_to: localhost
+
+- name: "check if transmit-delay is greater than 1 and less than 8192"
+  fail:
+    msg: "transmit_delay (valid-range: 1-8192)"
+  loop: "{{ lldp }}"
+  loop_control:
+    loop_var: item
+  when:
+    - item.transmit_delay is defined
+    - item.transmit_delay > "0"
+    - item.transmit_delay < 8192
+  delegate_to: localhost
+
+- name: "fetch template for configuring lldp"
+  set_fact:
+    junos_config_text: "{{ lookup('config_template', 'configure_lldp.j2') }}"
+  when: lldp
+  delegate_to: localhost
+
+- include_tasks: config_manager/load.yaml
+  when: lldp

--- a/templates/configure_lldp.j2
+++ b/templates/configure_lldp.j2
@@ -1,0 +1,23 @@
+{% for item in lldp %}
+
+{% if item.state is defined and item.state == 'absent' %}
+delete protocols lldp
+
+{% else %}
+
+set protocols lldp advertisement-interval {{ item.advertisement_interval | default(omit) }}
+set protocols lldp hold-multiplier {{ item.hold_multiplier | default(omit) }}
+{% if item.interface is defined %}
+set protocols lldp interface {{ item.interface | default(omit) }}
+{% endif %}
+set protocols lldp lldp-configuration-notification-interval {{ item.lcni | default(omit) }}
+set protocols lldp management-address {{ item.management_address | default(omit) }}
+set protocols lldp ptopo-configuration-maximum-hold-time {{ item.pcmht | default(omit) }}
+set protocols lldp ptopo-configuration-trap-interval {{ item.pcti | default(omit) }}
+set protocols lldp transmit-delay {{ item.transmit_delay | default(omit) }}
+{% if item.disble_interface is defined %}
+set protocols lldp interface {{ item.disble_interface }} disable
+{% endif %}
+
+{% endif %}
+{% endfor %}

--- a/tests/configure_lldp/tasks/configure_lldp.yaml
+++ b/tests/configure_lldp/tasks/configure_lldp.yaml
@@ -1,0 +1,52 @@
+---
+- debug: 
+    msg: "START configure_lldp function on connection={{ ansible_connection }}"
+
+- name: ensure netconf is enabled
+  junos_netconf:
+    netconf_port: "{{ netconf_port }}"
+
+- name: setup - remove lldp config
+  junos_config: &rm
+    lines:
+      - delete protocols lldp
+  connection: netconf
+
+- name: include juniper_junos load function
+  include_role:
+    name: "{{ juniper_junos_role_path }}"
+    tasks_from: configure_lldp
+  vars:
+    lldp:
+      - advertisement_interval: 60
+        hold_multiplier: 60
+        interface: all
+        lcni: 60
+        management_address: 192.168.1.1
+        pcmht: 4
+        pcti: 1
+        transmit_delay: 1
+        disble_interface: ge-0/0/2
+
+- name: fetch lldp config
+  junos_command:
+    commands: show configuration protocols lldp | display set
+  register: show_ptotocol_lldp_result
+
+- assert:
+    that:
+      - "'set protocols lldp management-address 192.168.1.1' in show_ptotocol_lldp_result.stdout_lines[0]"
+      - "'set protocols lldp advertisement-interval 60' in show_ptotocol_lldp_result.stdout_lines[0]"
+      - "'set protocols lldp transmit-delay 1' in show_ptotocol_lldp_result.stdout_lines[0]"
+      - "'set protocols lldp ptopo-configuration-trap-interval 1' in show_ptotocol_lldp_result.stdout_lines[0]"
+      - "'set protocols lldp ptopo-configuration-maximum-hold-time 4' in show_ptotocol_lldp_result.stdout_lines[0]"
+      - "'set protocols lldp lldp-configuration-notification-interval 60' in show_ptotocol_lldp_result.stdout_lines[0]"
+      - "'set protocols lldp interface all' in show_ptotocol_lldp_result.stdout_lines[0]"
+      - "'set protocols lldp interface ge-0/0/2 disable' in show_ptotocol_lldp_result.stdout_lines[0]"
+
+- name: teardown - remove lldp config
+  junos_config: *rm
+  connection: netconf
+
+- debug: 
+    msg: "END configure_lldp function on connection={{ ansible_connection }}"

--- a/tests/configure_lldp/tasks/main.yaml
+++ b/tests/configure_lldp/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: set role path
+  set_fact:
+    juniper_junos_role_path: "{{ role_path.split('/tests/configure_lldp/configure_lldp')[0] }}"
+
+- name: test configure_lldp function
+  import_tasks: configure_lldp.yml

--- a/tests/configure_lldp/test.yaml
+++ b/tests/configure_lldp/test.yaml
@@ -1,6 +1,6 @@
 - hosts: appliance
   connection: network_cli
   roles:
-    - configure_vlans
+    - configure_lldp
   vars:
     netconf_port: 830

--- a/tests/configure_lldp/test.yaml
+++ b/tests/configure_lldp/test.yaml
@@ -1,0 +1,6 @@
+- hosts: appliance
+  connection: network_cli
+  roles:
+    - configure_vlans
+  vars:
+    netconf_port: 830


### PR DESCRIPTION
Added `configure_lldp` and `configure_lldp` jinja template for Juniper Junos device provider to configure lldp using `junos` device provider role.

To configure lldp via this role user needs to build their playbook as:
```
- hosts: junos
  gather_facts: no
  tasks:
    - import_role:
        name: juniper_junos
        tasks_from: configure_lldp
      vars:
        lldp:
          - advertisement_interval: 60
            hold_multiplier: 60
            interface: all
            lcni: 60
            management_address: 192.168.1.1
            pcmht: 4
            pcti: 1
            transmit_delay: 1
            disble_interface: ge-0/0/2
            #state: absent
```