### PR TITLE
Added Alarm parsers and command map

### DIFF
--- a/docs/get_facts.md
+++ b/docs/get_facts.md
@@ -166,6 +166,7 @@ The default value is `default`
 * system
 * interfaces
 * bridging
+* alarms
 
 ### junos_get_facts_command_map
 

--- a/parser_templates/op/text/show_chassis_alarms.yaml
+++ b/parser_templates/op/text/show_chassis_alarms.yaml
@@ -1,0 +1,53 @@
+---
+- name: parser meta data
+  parser_metadata:
+    version: 1.0
+    command: show chassis alarms
+    network_os: junos
+
+- name: match sections
+  pattern_match:
+    regex: "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\w*)"
+    match_all: yes
+    match_greedy: yes
+  register: context
+
+- name: match alarms
+  pattern_group:
+    - name: match date and time
+      pattern_match:
+        regex: "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\w*)"
+        content: "{{ item }}"
+      register: date
+
+    - name: match alarm class
+      pattern_match:
+        regex: "(Major|Minor)"
+        content: "{{ item }}"
+      register: class
+
+    - name: alarm description
+      pattern_match:
+        regex: "(?:Major|Minor) (.*)"
+        content: "{{ item }}"
+      register: description
+
+  loop: "{{ context }}"
+  register: values
+
+- name: template interface values
+  loop: "{{ values }}"
+  register: alarms
+  export: yes
+  export_as: dict
+  extend: juniper_junos
+  json_template:
+    template:
+      - key: "{{ item.date.matches.0 }}"
+        object:
+          - key: date
+            value: "{{ item.date.matches.0 }}"
+          - key: class
+            value: "{{ item.class.matches.0 }}"
+          - key: description
+            value: "{{ item.description.matches.0 }}"

--- a/parser_templates/op/text/show_system_alarms.yaml
+++ b/parser_templates/op/text/show_system_alarms.yaml
@@ -1,0 +1,53 @@
+---
+- name: parser meta data
+  parser_metadata:
+    version: 1.0
+    command: show system alarms
+    network_os: junos
+
+- name: match sections
+  pattern_match:
+    regex: "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\w*)"
+    match_all: yes
+    match_greedy: yes
+  register: context
+
+- name: match alarms
+  pattern_group:
+    - name: match date and time
+      pattern_match:
+        regex: "(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\w*)"
+        content: "{{ item }}"
+      register: date
+
+    - name: match alarm class
+      pattern_match:
+        regex: "(Major|Minor)"
+        content: "{{ item }}"
+      register: class
+
+    - name: alarm description
+      pattern_match:
+        regex: "(?:Major|Minor) (.*)"
+        content: "{{ item }}"
+      register: description
+
+  loop: "{{ context }}"
+  register: values
+
+- name: template interface values
+  loop: "{{ values }}"
+  register: alarms
+  export: yes
+  export_as: dict
+  extend: juniper_junos
+  json_template:
+    template:
+      - key: "{{ item.date.matches.0 }}"
+        object:
+          - key: date
+            value: "{{ item.date.matches.0 }}"
+          - key: class
+            value: "{{ item.class.matches.0 }}"
+          - key: description
+            value: "{{ item.description.matches.0 }}"

--- a/vars/get_facts_command_map.yaml
+++ b/vars/get_facts_command_map.yaml
@@ -59,3 +59,17 @@
   groups:
     - default
     - system
+
+- command: show chassis alarms
+  parser: show_chassis_alarms.yaml
+  format: text
+  groups:
+    - default
+    - alarms
+
+- command: show system alarms
+  parser: show_system_alarms.yaml
+  format: text
+  groups:
+    - default
+    - alarms


### PR DESCRIPTION
Added additional parsers for Juniper commands "show chassis alarms" and "show system alarms". Below you can see the output from the mapping.
```
ok: [switch1] => {
    "msg": {
        "alarms": {
            "2018-12-21 11:02:59 UTC": {
                "class": "Minor", 
                "date": "2018-12-21 11:02:59 UTC", 
                "description": " Rescue configuration is not set"
            }, 
            "2018-12-21 11:06:03 UTC": {
                "class": "Minor", 
                "date": "2018-12-21 11:06:03 UTC", 
                "description": " FPC 0 PEM 0 is not powered"
```