### PR TITLE
OSPF Parser

### DIFF
--- a/docs/get_facts.md
+++ b/docs/get_facts.md
@@ -167,6 +167,7 @@ The default value is `default`
 * interfaces
 * bridging
 * alarms
+* routing
 
 ### junos_get_facts_command_map
 

--- a/parser_templates/op/text/show_ospf_neighbor_detail.yaml
+++ b/parser_templates/op/text/show_ospf_neighbor_detail.yaml
@@ -1,0 +1,69 @@
+---
+- name: parser meta data
+  parser_metadata:
+    version: 1.0
+    command: show ospf neighbor detail
+    network_os: junos
+
+- name: match sections
+  pattern_match:
+    regex: "^((?:[0-9]{1,3}\\.){3}[0-9]{1,3})\\s*([A-Za-z0-9\\-/.]*)\\s*(\\w*)"
+    match_all: yes
+    match_greedy: yes
+  register: context
+
+- name: match neighbor ip values
+  pattern_group:
+    - name: match IP
+      pattern_match:
+        regex: "^((?:[0-9]{1,3}\\.){3}[0-9]{1,3})"
+        content: "{{ item }}"
+      register: ip
+
+    - name: match ospf interface
+      pattern_match:
+        regex: "^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\s*([A-Za-z0-9\\-/.]*)\\s*\\w*"
+        content: "{{ item }}"
+      register: interface
+
+    - name: match ospf state
+      pattern_match:
+        regex: "^(?:(?:[0-9]{1,3}\\.){3}[0-9]{1,3})\\s*(?:[A-Za-z0-9\\-/.]*)\\s*(\\w*)"
+        content: "{{ item }}"
+      register: state
+
+    - name: match ospf area
+      pattern_match:
+        regex: "Area ((?:[0-9]{1,3}\\.){3}[0-9]{1,3})"
+        content: "{{ item }}"
+      register: area
+
+    - name: match ospf uptime
+      pattern_match:
+        regex: "Up (.*),"
+        content: "{{ item }}"
+      register: uptime
+
+  loop: "{{ context }}"
+  register: values
+
+- name: template interface values
+  loop: "{{ values }}"
+  register: routing
+  export: yes
+  export_as: dict
+  extend: juniper_junos
+  json_template:
+    template:
+      - key: "{{ item.ip.matches.0 }}"
+        object:
+          - key: ip
+            value: "{{ item.ip.matches.0 }}"
+          - key: area
+            value: "{{ item.area.matches.0 }}"
+          - key: interface
+            value: "{{ item.interface.matches.0 }}"
+          - key: state
+            value: "{{ item.state.matches.0 }}"
+          - key: uptime
+            value: "{{ item.uptime.matches.0 }}"

--- a/vars/get_facts_command_map.yaml
+++ b/vars/get_facts_command_map.yaml
@@ -73,3 +73,10 @@
   groups:
     - default
     - alarms
+
+- command: show ospf neighbor detail
+  parser: show_ospf_neighbor_detail.yaml
+  format: text
+  groups:
+    - default
+    - routing


### PR DESCRIPTION
Replacement Pull Request for #33

Submitting a new Juniper parser for command "show ospf neighbor detail". Below you will see the results of us running the command through the parser file.

TASK [juniper_junos : print facts text] ***************************************************************************************************************
ok: [router1] => {
    "msg": {
        "capabilities": {
            "network_os": "junos",
            "network_os_hostname": "router1",
            "network_os_model": "srx340",
            "network_os_version": "15.1X49-D45"
        },
        "routing": {
            "10.0.10.1": {
                "area": "0.0.0.1",
                "interface": "st0.7",
                "ip": "10.0.10.1",
                "state": "Full",
                "uptime": "5d 07:39:53"
            },
            "10.0.3.1": {
                "area": "0.0.0.1",
                "interface": "st0.2",
                "ip": "10.0.3.1",
                "state": "Full",
                "uptime": "5d 20:58:09"
            },
            "10.0.4.1": {
                "area": "0.0.0.1",
                "interface": "st0.3",
                "ip": "10.0.4.1",
                "state": "Full",
                "uptime": "5d 20:58:13"
            },
            "10.0.5.1": {
                "area": "0.0.0.1",
                "interface": "st0.4",
                "ip": "10.0.5.1",
                "state": "Full",
                "uptime": "5d 10:59:13"
            },
            "10.0.6.1": {
                "area": "0.0.0.1",
                "interface": "st0.8",
                "ip": "10.0.6.1",
                "state": "Full",
                "uptime": "5d 18:49:44"
            },
            "10.0.7.1": {
                "area": "0.0.0.1",
                "interface": "st0.9",
                "ip": "10.0.7.1",
                "state": "Full",
                "uptime": "5d 20:59:31"
            },
            "10.0.8.1": {
                "area": "0.0.0.1",
                "interface": "st0.5",
                "ip": "10.0.8.1",
                "state": "Full",
                "uptime": "5d 20:40:12"
            },
            "10.0.9.1": {
                "area": "0.0.0.1",
                "interface": "st0.6",
                "ip": "10.0.9.1",
                "state": "Full",
                "uptime": "5d 12:42:33"
            },
            "10.1.1.1": {
                "area": "0.0.0.1",
                "interface": "st0.1",
                "ip": "10.1.1.1",
                "state": "Full",
                "uptime": "5d 20:58:32"
            }
        }
    }
}